### PR TITLE
bugfix/instance-state

### DIFF
--- a/commons/src/main/java/com/github/globocom/viewport/commons/ViewPortSavedState.kt
+++ b/commons/src/main/java/com/github/globocom/viewport/commons/ViewPortSavedState.kt
@@ -1,13 +1,24 @@
 package com.github.globocom.viewport.commons
 
+import android.os.Build
 import android.os.Parcel
 import android.os.Parcelable
 import android.view.View
+import androidx.annotation.RequiresApi
 
 class ViewPortSavedState : View.BaseSavedState {
     companion object {
-        val CREATOR: Parcelable.Creator<ViewPortSavedState?> =
-            object : Parcelable.Creator<ViewPortSavedState?> {
+        @JvmField
+        val CREATOR: Parcelable.ClassLoaderCreator<ViewPortSavedState?> =
+            object : Parcelable.ClassLoaderCreator<ViewPortSavedState?> {
+                @RequiresApi(Build.VERSION_CODES.N)
+                override fun createFromParcel(
+                    source: Parcel,
+                    loader: ClassLoader?
+                ): ViewPortSavedState? {
+                    return ViewPortSavedState(source, loader)
+                }
+
                 override fun createFromParcel(`in`: Parcel): ViewPortSavedState? {
                     return ViewPortSavedState(`in`)
                 }
@@ -26,21 +37,29 @@ class ViewPortSavedState : View.BaseSavedState {
 
     constructor(superState: Parcelable?) : super(superState)
 
+    @RequiresApi(Build.VERSION_CODES.N)
+    private constructor(parcel: Parcel, loader: ClassLoader?) : super(parcel, loader) {
+        setupWith(parcel)
+    }
+
     private constructor(parcel: Parcel) : super(parcel) {
+        setupWith(parcel)
+    }
+
+    private fun setupWith(parcel: Parcel) {
         isHearBeatStarted = parcel.readByte() != 0.toByte()
         isLibStarted = parcel.readByte() != 0.toByte()
-        currentVisibleItemsList =
-            (parcel.createIntArray() ?: mutableListOf<Int>()) as MutableList<Int>
-        previouslyVisibleItemsList = (parcel.createIntArray() ?: mutableListOf<Int>()) as MutableList<Int>
-        oldItemsList = (parcel.createIntArray() ?: mutableListOf<Int>()) as MutableList<Int>
+        currentVisibleItemsList = (parcel.createIntArray()?.toMutableList() ?: mutableListOf())
+        previouslyVisibleItemsList = (parcel.createIntArray()?.toMutableList() ?: mutableListOf())
+        oldItemsList = (parcel.createIntArray()?.toMutableList() ?: mutableListOf())
     }
 
     override fun writeToParcel(out: Parcel, flags: Int) {
         super.writeToParcel(out, flags)
         out.writeByte(if (isHearBeatStarted) 1 else 0)
         out.writeByte(if (isLibStarted) 1 else 0)
-        out.writeList(currentVisibleItemsList as MutableList<*>?)
-        out.writeList(previouslyVisibleItemsList as MutableList<*>?)
-        out.writeList(oldItemsList as MutableList<*>?)
+        out.writeIntArray(currentVisibleItemsList.toIntArray())
+        out.writeIntArray(previouslyVisibleItemsList.toIntArray())
+        out.writeIntArray(oldItemsList.toIntArray())
     }
 }

--- a/library-mobile/src/main/java/com/github/globocom/viewport/mobile/ViewPortRecyclerView.kt
+++ b/library-mobile/src/main/java/com/github/globocom/viewport/mobile/ViewPortRecyclerView.kt
@@ -139,7 +139,6 @@ open class ViewPortRecyclerView @JvmOverloads constructor(
         if (state is ViewPortSavedState) {
             super.onRestoreInstanceState(state.superState)
             viewPortManager?.onRestoreInstanceState(state)
-            requestLayout()
         } else {
             super.onRestoreInstanceState(state)
         }

--- a/library-mobile/src/main/java/com/github/globocom/viewport/mobile/ViewPortRecyclerView.kt
+++ b/library-mobile/src/main/java/com/github/globocom/viewport/mobile/ViewPortRecyclerView.kt
@@ -132,16 +132,17 @@ open class ViewPortRecyclerView @JvmOverloads constructor(
         val superState = super.onSaveInstanceState()
         val myState = ViewPortSavedState(superState)
 
-        return viewPortManager?.onSaveInstanceState(myState)
+        return viewPortManager?.onSaveInstanceState(myState) ?: superState
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        val savedState = state as? ViewPortSavedState
-        super.onRestoreInstanceState(savedState?.superState)
-
-        viewPortManager?.onRestoreInstanceState(savedState)
-
-        requestLayout()
+        if (state is ViewPortSavedState) {
+            super.onRestoreInstanceState(state.superState)
+            viewPortManager?.onRestoreInstanceState(state)
+            requestLayout()
+        } else {
+            super.onRestoreInstanceState(state)
+        }
     }
 
     /**

--- a/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortHorizontalGridView.kt
+++ b/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortHorizontalGridView.kt
@@ -116,7 +116,6 @@ open class ViewPortHorizontalGridView @JvmOverloads constructor(
         if (state is ViewPortSavedState) {
             super.onRestoreInstanceState(state.superState)
             viewPortManager?.onRestoreInstanceState(state)
-            requestLayout()
         } else {
             super.onRestoreInstanceState(state)
         }

--- a/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortHorizontalGridView.kt
+++ b/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortHorizontalGridView.kt
@@ -109,16 +109,17 @@ open class ViewPortHorizontalGridView @JvmOverloads constructor(
         val superState = super.onSaveInstanceState()
         val myState = ViewPortSavedState(superState)
 
-        return viewPortManager?.onSaveInstanceState(myState)
+        return viewPortManager?.onSaveInstanceState(myState) ?: superState
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        val savedState = state as? ViewPortSavedState
-        super.onRestoreInstanceState(savedState?.superState)
-
-        viewPortManager?.onRestoreInstanceState(savedState)
-
-        requestLayout()
+        if (state is ViewPortSavedState) {
+            super.onRestoreInstanceState(state.superState)
+            viewPortManager?.onRestoreInstanceState(state)
+            requestLayout()
+        } else {
+            super.onRestoreInstanceState(state)
+        }
     }
 
     /**

--- a/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortVerticalGridView.kt
+++ b/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortVerticalGridView.kt
@@ -112,7 +112,6 @@ open class ViewPortVerticalGridView @JvmOverloads constructor(
         if (state is ViewPortSavedState) {
             super.onRestoreInstanceState(state.superState)
             viewPortManager?.onRestoreInstanceState(state)
-            requestLayout()
         } else {
             super.onRestoreInstanceState(state)
         }

--- a/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortVerticalGridView.kt
+++ b/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortVerticalGridView.kt
@@ -105,16 +105,17 @@ open class ViewPortVerticalGridView @JvmOverloads constructor(
         val superState = super.onSaveInstanceState()
         val myState = ViewPortSavedState(superState)
 
-        return viewPortManager?.onSaveInstanceState(myState)
+        return viewPortManager?.onSaveInstanceState(myState) ?: superState
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        val savedState = state as? ViewPortSavedState
-        super.onRestoreInstanceState(savedState?.superState)
-
-        viewPortManager?.onRestoreInstanceState(savedState)
-
-        requestLayout()
+        if (state is ViewPortSavedState) {
+            super.onRestoreInstanceState(state.superState)
+            viewPortManager?.onRestoreInstanceState(state)
+            requestLayout()
+        } else {
+            super.onRestoreInstanceState(state)
+        }
     }
 
     /**


### PR DESCRIPTION
> # :bug: PULL REQUEST BUG :bug:

### Description
InstanceState was not being properly saved and restored, sometimes causing app crashes


### Does this introduce an urgent change?
- [x] Yes
- [ ] No


### Steps to reproduce the problem
1. Turn on `Don't keep activities` under the Developer Options menu
2. Run the sample
3. Rotate the screen, or put app in background and bring it back


### Logs
<img width="919" alt="Captura de Tela 2020-07-08 às 16 52 17" src="https://user-images.githubusercontent.com/10567250/86987601-d60c9900-c16c-11ea-9e05-def9b64c4c69.png">


### Build
Check that your PR meets the following requirements:

- [x] Build (`assembleRelease`) was run locally and got no errors
- [x] Proguard passed locally and there are no failures


### Analysis and Conclusion
By fixing warnings, reading documentations and poking around the platform's code