### PR TITLE
bugfix/instance-state-viewports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ ext {
     jUnit_version = '1.0.0'
     robolectric_version = '4.3.1'
     support_version = '1.0.0'
-    commons_version = '1.2.0'
+    commons_version = '1.3.0'
     viewport_mobile_version = '1.1.0'
     viewport_tv_version = '1.1.0'
     mockK_version = '1.9.2'

--- a/library-mobile/src/main/java/com/github/globocom/viewport/mobile/ViewPortRecyclerView.kt
+++ b/library-mobile/src/main/java/com/github/globocom/viewport/mobile/ViewPortRecyclerView.kt
@@ -1,6 +1,7 @@
 package com.github.globocom.viewport.mobile
 
 import android.content.Context
+import android.os.Bundle
 import android.os.Handler
 import android.os.Parcelable
 import android.util.AttributeSet
@@ -9,7 +10,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.github.globocom.viewport.commons.ViewPortLiveData
 import com.github.globocom.viewport.commons.ViewPortManager
-import com.github.globocom.viewport.commons.ViewPortSavedState
 
 open class ViewPortRecyclerView @JvmOverloads constructor(
     context: Context,
@@ -22,6 +22,12 @@ open class ViewPortRecyclerView @JvmOverloads constructor(
 
     private companion object {
         const val SCROLL_IDLE_TIME = 500L
+        const val INSTANCE_STATE_SUPER_STATE = "instanceStateSuperState"
+        const val INSTANCE_STATE_IS_HEAR_BEAT_STARTED = "instanceStateIsHearBeatStarted"
+        const val INSTANCE_STATE_IS_LIB_STARTED = "instanceStateIsLibStarted"
+        const val INSTANCE_STATE_CURRENT_VISIBLE_ITEMS_LIST = "instanceStateCurrentVisibleItemsList"
+        const val INSTANCE_STATE_PREVIOUSLY_VISIBLE_ITEMS_LIST = "instanceStatePreviouslyVisibleItemsList"
+        const val INSTANCE_STATE_OLD_ITEMS_LIST = "instanceStateOldItemsList"
     }
 
     /**
@@ -127,18 +133,32 @@ open class ViewPortRecyclerView @JvmOverloads constructor(
             viewPortManager?.startLib()
         }
 
-
     override fun onSaveInstanceState(): Parcelable? {
         val superState = super.onSaveInstanceState()
-        val myState = ViewPortSavedState(superState)
+        val myState = Bundle()
+        myState.putParcelable(INSTANCE_STATE_SUPER_STATE, superState)
 
-        return viewPortManager?.onSaveInstanceState(myState) ?: superState
+        viewPortManager?.let {
+            myState.putBoolean(INSTANCE_STATE_IS_HEAR_BEAT_STARTED, it.isHearBeatStarted)
+            myState.putBoolean(INSTANCE_STATE_IS_LIB_STARTED, it.isLibStarted)
+            myState.putIntArray(INSTANCE_STATE_CURRENT_VISIBLE_ITEMS_LIST, it.currentVisibleItemsList.toIntArray())
+            myState.putIntArray(INSTANCE_STATE_PREVIOUSLY_VISIBLE_ITEMS_LIST, it.previouslyVisibleItemsList.toIntArray())
+            myState.putIntArray(INSTANCE_STATE_OLD_ITEMS_LIST, it.oldItemsList.toIntArray())
+        }
+
+        return myState
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        if (state is ViewPortSavedState) {
-            super.onRestoreInstanceState(state.superState)
-            viewPortManager?.onRestoreInstanceState(state)
+        if (state is Bundle) {
+            super.onRestoreInstanceState(state.getParcelable(INSTANCE_STATE_SUPER_STATE))
+            viewPortManager?.apply {
+                isHearBeatStarted = state.getBoolean(INSTANCE_STATE_IS_HEAR_BEAT_STARTED)
+                isLibStarted = state.getBoolean(INSTANCE_STATE_IS_LIB_STARTED)
+                currentVisibleItemsList = state.getIntArray(INSTANCE_STATE_CURRENT_VISIBLE_ITEMS_LIST)?.toMutableList() ?: mutableListOf()
+                previouslyVisibleItemsList = state.getIntArray(INSTANCE_STATE_PREVIOUSLY_VISIBLE_ITEMS_LIST)?.toMutableList() ?: mutableListOf()
+                oldItemsList = state.getIntArray(INSTANCE_STATE_OLD_ITEMS_LIST)?.toMutableList() ?: mutableListOf()
+            }
         } else {
             super.onRestoreInstanceState(state)
         }

--- a/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortVerticalGridView.kt
+++ b/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortVerticalGridView.kt
@@ -1,6 +1,7 @@
 package com.github.globocom.viewport.tv
 
 import android.content.Context
+import android.os.Bundle
 import android.os.Parcelable
 import android.util.AttributeSet
 import android.view.View
@@ -11,7 +12,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.github.globocom.viewport.commons.ViewPortGridViewHelper
 import com.github.globocom.viewport.commons.ViewPortLiveData
 import com.github.globocom.viewport.commons.ViewPortManager
-import com.github.globocom.viewport.commons.ViewPortSavedState
 
 open class ViewPortVerticalGridView @JvmOverloads constructor(
     context: Context,
@@ -20,6 +20,15 @@ open class ViewPortVerticalGridView @JvmOverloads constructor(
 ) : VerticalGridView(context, attrs, defStyleAttr), LifecycleObserver {
     init {
         isSaveEnabled = true
+    }
+
+    private companion object {
+        const val INSTANCE_STATE_SUPER_STATE = "instanceStateSuperState"
+        const val INSTANCE_STATE_IS_HEAR_BEAT_STARTED = "instanceStateIsHearBeatStarted"
+        const val INSTANCE_STATE_IS_LIB_STARTED = "instanceStateIsLibStarted"
+        const val INSTANCE_STATE_CURRENT_VISIBLE_ITEMS_LIST = "instanceStateCurrentVisibleItemsList"
+        const val INSTANCE_STATE_PREVIOUSLY_VISIBLE_ITEMS_LIST = "instanceStatePreviouslyVisibleItemsList"
+        const val INSTANCE_STATE_OLD_ITEMS_LIST = "instanceStateOldItemsList"
     }
 
     private var viewPortManager: ViewPortManager? = null
@@ -103,15 +112,30 @@ open class ViewPortVerticalGridView @JvmOverloads constructor(
 
     override fun onSaveInstanceState(): Parcelable? {
         val superState = super.onSaveInstanceState()
-        val myState = ViewPortSavedState(superState)
+        val myState = Bundle()
+        myState.putParcelable(INSTANCE_STATE_SUPER_STATE, superState)
 
-        return viewPortManager?.onSaveInstanceState(myState) ?: superState
+        viewPortManager?.let {
+            myState.putBoolean(INSTANCE_STATE_IS_HEAR_BEAT_STARTED, it.isHearBeatStarted)
+            myState.putBoolean(INSTANCE_STATE_IS_LIB_STARTED, it.isLibStarted)
+            myState.putIntArray(INSTANCE_STATE_CURRENT_VISIBLE_ITEMS_LIST, it.currentVisibleItemsList.toIntArray())
+            myState.putIntArray(INSTANCE_STATE_PREVIOUSLY_VISIBLE_ITEMS_LIST, it.previouslyVisibleItemsList.toIntArray())
+            myState.putIntArray(INSTANCE_STATE_OLD_ITEMS_LIST, it.oldItemsList.toIntArray())
+        }
+
+        return myState
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        if (state is ViewPortSavedState) {
-            super.onRestoreInstanceState(state.superState)
-            viewPortManager?.onRestoreInstanceState(state)
+        if (state is Bundle) {
+            super.onRestoreInstanceState(state.getParcelable(INSTANCE_STATE_SUPER_STATE))
+            viewPortManager?.apply {
+                isHearBeatStarted = state.getBoolean(INSTANCE_STATE_IS_HEAR_BEAT_STARTED)
+                isLibStarted = state.getBoolean(INSTANCE_STATE_IS_LIB_STARTED)
+                currentVisibleItemsList = state.getIntArray(INSTANCE_STATE_CURRENT_VISIBLE_ITEMS_LIST)?.toMutableList() ?: mutableListOf()
+                previouslyVisibleItemsList = state.getIntArray(INSTANCE_STATE_PREVIOUSLY_VISIBLE_ITEMS_LIST)?.toMutableList() ?: mutableListOf()
+                oldItemsList = state.getIntArray(INSTANCE_STATE_OLD_ITEMS_LIST)?.toMutableList() ?: mutableListOf()
+            }
         } else {
             super.onRestoreInstanceState(state)
         }


### PR DESCRIPTION
> # :bug: PULL REQUEST BUG :bug:

### Description
Crashes on devices with API level lower than N


### Does this introduce an urgent change?
- [ ] Yes
- [ ] No


### Steps to reproduce the problem
1. Turn on `Don't keep activities` under the Developer Options menu
2. Run the sample on an Android with API level lower than N
3. Rotate the screen, or put app in background and bring it back


### Logs
https://console.firebase.google.com/u/0/project/globo-play/crashlytics/app/android:com.globo.globotv/issues/a66880aa2e5ba33dbdabfdcd7d10fc07?time=last-seven-days&sessionId=5F0D15AE009C000144A7F7E0E0F7EB23_DNE_0_v2


### Build
Check that your PR meets the following requirements:

- [x] Build (`assembleRelease`) was run locally and got no errors
- [x] Proguard passed locally and there are no failures


### Analysis and Conclusion
System can't restore `SavedInstanceState` without a ClassLoader, but this is only available on `View.BaseSavedState` on API N and above. So the solution applied was to use a `Bundle` instead of `ViewPortSavedState`.