### PR TITLE
bugfix/recyclerview-no-position

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.3.72'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
 
     }
     dependencies {
@@ -14,7 +14,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/commons/src/main/java/com/github/globocom/viewport/commons/ViewPortManager.kt
+++ b/commons/src/main/java/com/github/globocom/viewport/commons/ViewPortManager.kt
@@ -82,7 +82,9 @@ class ViewPortManager(
         val lastItemPosition = it.second
 
         // Gets range of current completely visible items positions.
-        currentVisibleItemsList = (firstItemPosition..lastItemPosition).toMutableList()
+        currentVisibleItemsList = (firstItemPosition..lastItemPosition).filterNot { position ->
+            position < 0
+        }.toMutableList()
 
         // Updates old items viewed.
         if (oldItemsList.none()) {

--- a/commons/src/main/java/com/github/globocom/viewport/commons/ViewPortManager.kt
+++ b/commons/src/main/java/com/github/globocom/viewport/commons/ViewPortManager.kt
@@ -64,7 +64,7 @@ class ViewPortManager(
                 // If there are 'continue visible' items since last pulse, updates list
                 // avoiding repeat already viewed items.
                 val valueWillChange = viewPortLiveData.value != continueVisibleItemsList
-                if (!continueVisibleItemsList.none() && valueWillChange) {
+                if (continueVisibleItemsList.isNotEmpty() && valueWillChange) {
                     viewPortLiveData.value = continueVisibleItemsList
 
                     // Get only new items by removing previous items from current visible ones
@@ -87,7 +87,7 @@ class ViewPortManager(
         }.toMutableList()
 
         // Updates old items viewed.
-        if (oldItemsList.none()) {
+        if (oldItemsList.isEmpty()) {
             oldItemsList = currentVisibleItemsList
         }
     }


### PR DESCRIPTION
> # :bug: PULL REQUEST BUG :bug:

### Description
Prevents invalid positions (actually `-1`, from [RecyclerView.NO_POSITION](https://developer.android.com/reference/androidx/recyclerview/widget/RecyclerView#NO_POSITION)) from being emitted.


### Does this introduce an urgent change?
- [ ] Yes
- [ ] No


### Steps to reproduce the problem
1. Apply viewport with items whose sizes span more than half of the screen;
2. Perform slow scrolls which allows both items to be partially visible;
3. Viewport will emit the `-1` "no position" value on both `LiveData`s.


### Logs
![negative_index](https://user-images.githubusercontent.com/10567250/149807941-52820df9-27a7-4e99-8b97-240c4a9311e3.png)

```
2022-01-17 13:29:17.380 12605-12810/com.globo.globotv.homolog V/Teste: {area=home.globo-play-beta, areaTitle=home_anonimo, actionType=impressao, destination=categoria, componentType=trilho, componentLabel=categorias, componentItem=poster, componentItemLabel=novelas, componentItemId=novelas, componentHorizontal=1, componentVertical=4}
2022-01-17 13:29:17.391 12605-12899/com.globo.globotv.homolog V/Teste: {area=home.globo-play-beta, areaTitle=home_anonimo, actionType=impressao, destination=null, componentType=trilho, componentLabel=categorias, componentItem=trilho, componentItemLabel=null, componentItemId=null, componentHorizontal=0, componentVertical=4}
2022-01-17 13:29:23.628 12605-12899/com.globo.globotv.homolog V/Teste: {area=home.globo-play-beta, areaTitle=home_anonimo, actionType=impressao, destination=categoria, componentType=trilho, componentLabel=categorias, componentItem=poster, componentItemLabel=series, componentItemId=series, componentHorizontal=2, componentVertical=4}
2022-01-17 13:29:27.494 12605-12899/com.globo.globotv.homolog V/Teste: {area=home.globo-play-beta, areaTitle=home_anonimo, actionType=impressao, destination=null, componentType=trilho, componentLabel=categorias, componentItem=trilho, componentItemLabel=null, componentItemId=null, componentHorizontal=0, componentVertical=4}
2022-01-17 13:29:28.827 12605-12899/com.globo.globotv.homolog V/Teste: {area=home.globo-play-beta, areaTitle=home_anonimo, actionType=impressao, destination=categoria, componentType=trilho, componentLabel=categorias, componentItem=poster, componentItemLabel=filmes, componentItemId=filmes, componentHorizontal=3, componentVertical=4}
2022-01-17 13:29:31.041 12605-12899/com.globo.globotv.homolog V/Teste: {area=home.globo-play-beta, areaTitle=home_anonimo, actionType=impressao, destination=null, componentType=trilho, componentLabel=categorias, componentItem=trilho, componentItemLabel=null, componentItemId=null, componentHorizontal=0, componentVertical=4}
2022-01-17 13:29:31.852 12605-12899/com.globo.globotv.homolog V/Teste: {area=home.globo-play-beta, areaTitle=home_anonimo, actionType=impressao, destination=categoria, componentType=trilho, componentLabel=categorias, componentItem=poster, componentItemLabel=bbb, componentItemId=big_brother_brasil, componentHorizontal=4, componentVertical=4}
2022-01-17 13:29:33.599 12605-12899/com.globo.globotv.homolog V/Teste: {area=home.globo-play-beta, areaTitle=home_anonimo, actionType=impressao, destination=null, componentType=trilho, componentLabel=categorias, componentItem=trilho, componentItemLabel=null, componentItemId=null, componentHorizontal=0, componentVertical=4}
2022-01-17 13:29:34.647 12605-12899/com.globo.globotv.homolog V/Teste: {area=home.globo-play-beta, areaTitle=home_anonimo, actionType=impressao, destination=categoria, componentType=trilho, componentLabel=categorias, componentItem=poster, componentItemLabel=infantil, componentItemId=infantil, componentHorizontal=5, componentVertical=4}
```


### Build
Check that your PR meets the following requirements:

- [x] Build (`assembleRelease`) was run locally and got no errors
- [x] Proguard passed locally and there are no failures


### Analysis and Conclusion
By checking metrics event logs of new components, some strange behaviors were perceived. Then has been noticed that with larger elements `-1` value was being emitted and that was causing some troubles. So in order to solve the problem across all usage places it was devised to filter invalid positions and emit only really visible ones, omitting the "no position" value from emissions.