### PR TITLE
bugfix/memory-leaks-after-reuse

### DIFF
--- a/library-mobile/src/main/java/com/github/globocom/viewport/mobile/ViewPortRecyclerView.kt
+++ b/library-mobile/src/main/java/com/github/globocom/viewport/mobile/ViewPortRecyclerView.kt
@@ -136,9 +136,11 @@ open class ViewPortRecyclerView @JvmOverloads constructor(
         set(value) {
             if (field == value) return
 
+            field?.lifecycle?.removeObserver(this)
             field = value
             field?.lifecycle?.addObserver(this)
 
+            viewPortManager?.stopLib()
             viewPortManager = ViewPortManager(firstAndLastVisibleItemsLiveData, field)
 
             field?.let {

--- a/library-mobile/src/main/java/com/github/globocom/viewport/mobile/ViewPortRecyclerView.kt
+++ b/library-mobile/src/main/java/com/github/globocom/viewport/mobile/ViewPortRecyclerView.kt
@@ -134,6 +134,8 @@ open class ViewPortRecyclerView @JvmOverloads constructor(
      */
     var lifecycleOwner: LifecycleOwner? = null
         set(value) {
+            if (field == value) return
+
             field = value
             field?.lifecycle?.addObserver(this)
 

--- a/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortHorizontalGridView.kt
+++ b/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortHorizontalGridView.kt
@@ -88,9 +88,11 @@ open class ViewPortHorizontalGridView @JvmOverloads constructor(
         set(value) {
             if (field == value) return
 
+            field?.lifecycle?.removeObserver(this)
             field = value
             field?.lifecycle?.addObserver(this)
 
+            viewPortManager?.stopLib()
             viewPortManager = ViewPortManager(firstAndLastVisibleItemsLiveData, field)
 
             field?.let {

--- a/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortHorizontalGridView.kt
+++ b/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortHorizontalGridView.kt
@@ -86,6 +86,8 @@ open class ViewPortHorizontalGridView @JvmOverloads constructor(
      */
     var lifecycleOwner: LifecycleOwner? = null
         set(value) {
+            if (field == value) return
+
             field = value
             field?.lifecycle?.addObserver(this)
 

--- a/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortVerticalGridView.kt
+++ b/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortVerticalGridView.kt
@@ -86,9 +86,11 @@ open class ViewPortVerticalGridView @JvmOverloads constructor(
         set(value) {
             if (field == value) return
 
+            field?.lifecycle?.removeObserver(this)
             field = value
             field?.lifecycle?.addObserver(this)
 
+            viewPortManager?.stopLib()
             viewPortManager = ViewPortManager(firstAndLastVisibleItemsLiveData, field)
 
             field?.let {

--- a/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortVerticalGridView.kt
+++ b/library-tv/src/main/java/com/github/globocom/viewport/tv/ViewPortVerticalGridView.kt
@@ -84,6 +84,8 @@ open class ViewPortVerticalGridView @JvmOverloads constructor(
      */
     var lifecycleOwner: LifecycleOwner? = null
         set(value) {
+            if (field == value) return
+
             field = value
             field?.lifecycle?.addObserver(this)
 


### PR DESCRIPTION
> # :bug: PULL REQUEST BUG :bug:

### Description
Prevents memory leaks caused by `lifecycleOwner` updates (commonly done when being used and recycled while nested inside other `RecyclerView`s).


### Does this introduce an urgent change?
- [ ] Yes
- [x] No


### Steps to reproduce the problem
1. Set `lifecycleOwner` twice, or reuse the viewport (e.g., inside a RecyclerView).
   - the [rih-carv/view-port/feature/mobile-sample-nested](https://github.com/rih-carv/view-port/tree/feature/mobile-sample-nested) and [rih-carv/view-port/feature/tv-sample](https://github.com/rih-carv/view-port/tree/feature/tv-sample) branches provides suitable scenarios to reproduce the memory leaks, by performing some vertical scrolls after selecting `NestedLayout`.


### Logs
| Before | After |
| --- | --- |
| ![heap dump with leak](https://user-images.githubusercontent.com/10567250/180860106-9c3efb01-3462-4fc1-9f22-445e0600637e.png) | ![heap dump without leak](https://user-images.githubusercontent.com/10567250/180860233-8fb6d4f9-3cd8-4a5e-a7eb-155176d72d66.png) |


### Build
Check that your PR meets the following requirements:

- [x] Build (`assembleRelease`) was run locally and got no errors
- [x] Proguard passed locally and there are no failures


### Analysis and Conclusion
Scroll performance was getting worse over time on low-end devices, like Fire TV.
Also, there were very frequent GC invocations during navigation. After checking some heap dumps, all evidence pointed to `ViewportManager` holding `LifecycleOwner` and being held by `Message` objects from `CountDownTimer`.

After code analysis, the conclusion was that upon Viewport reuse inside of `RecyclerView`'s `ViewHolder`s, `lifecycleOwner` gets updated. That update then recreates `ViewportManager` while its old instance was never stopped (neither before such replacement nor when `lifecycleOwner` gets destroyed). That dangling old instances then keep their references to `LifecycleOwner` forever and never get deallocated because of the unstopped `CountDownTimer`'s implicit references to them through their lambdas.